### PR TITLE
Drag-drop zone, <dialog> history, copy transcript, format picker (P2+P3)

### DIFF
--- a/whisper_video_to_text/web/static/app.js
+++ b/whisper_video_to_text/web/static/app.js
@@ -222,42 +222,46 @@ function listen(jobId) {
   };
 }
 
-async function toggleHistory() {
+async function openHistory() {
   const modal = document.getElementById('history-modal');
   const list = document.getElementById('history-list');
 
-  if (modal.hidden) {
-    modal.hidden = false;
+  if (typeof modal.showModal === 'function') modal.showModal();
+  else modal.setAttribute('open', '');
+
+  list.replaceChildren();
+  const loading = document.createElement('div');
+  loading.className = 'meta';
+  loading.textContent = 'Loading...';
+  list.appendChild(loading);
+
+  try {
+    const res = await fetch('/api/history');
+    const history = await res.json();
     list.replaceChildren();
-    const loading = document.createElement('div');
-    loading.className = 'meta';
-    loading.textContent = 'Loading...';
-    list.appendChild(loading);
 
-    try {
-      const res = await fetch('/api/history');
-      const history = await res.json();
-      list.replaceChildren();
-
-      if (history.length === 0) {
-        const empty = document.createElement('div');
-        empty.className = 'meta';
-        empty.textContent = 'No transcripts found.';
-        list.appendChild(empty);
-        return;
-      }
-
-      history.forEach(item => list.appendChild(buildHistoryItem(item)));
-    } catch (err) {
-      list.replaceChildren();
-      const errEl = document.createElement('div');
-      errEl.className = 'meta error-text';
-      errEl.textContent = `Error loading history: ${err.message}`;
-      list.appendChild(errEl);
+    if (history.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'meta';
+      empty.textContent = 'No transcripts found.';
+      list.appendChild(empty);
+      return;
     }
-  } else {
-    modal.hidden = true;
+
+    history.forEach(item => list.appendChild(buildHistoryItem(item)));
+  } catch (err) {
+    list.replaceChildren();
+    const errEl = document.createElement('div');
+    errEl.className = 'meta error-text';
+    errEl.textContent = `Error loading history: ${err.message}`;
+    list.appendChild(errEl);
   }
+}
+
+function closeHistory() {
+  const modal = document.getElementById('history-modal');
+  if (typeof modal.close === 'function') modal.close();
+  else modal.removeAttribute('open');
 }
 
 function buildHistoryItem(item) {
@@ -285,6 +289,110 @@ function buildHistoryItem(item) {
   return card;
 }
 
+function formatSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(n >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function showFilePreview(file) {
+  const zone = document.getElementById('file-zone');
+  const drop = document.getElementById('file-zone-drop');
+  const preview = document.getElementById('file-preview');
+  const name = document.getElementById('file-preview-name');
+  const size = document.getElementById('file-preview-size');
+  if (!file) {
+    drop.hidden = false;
+    preview.hidden = true;
+    zone.classList.remove('file-zone--filled');
+    return;
+  }
+  name.textContent = file.name;
+  size.textContent = formatSize(file.size);
+  drop.hidden = true;
+  preview.hidden = false;
+  zone.classList.add('file-zone--filled');
+}
+
+function clearFile() {
+  const input = document.getElementById('file');
+  input.value = '';
+  showFilePreview(null);
+}
+
+function wireFileZone() {
+  const input = document.getElementById('file');
+  const drop = document.getElementById('file-zone-drop');
+  const remove = document.getElementById('file-remove');
+
+  input.addEventListener('change', () => {
+    const file = input.files && input.files[0];
+    showFilePreview(file || null);
+    if (file) clearError();
+  });
+
+  remove.addEventListener('click', clearFile);
+
+  ['dragenter', 'dragover'].forEach(evt => {
+    drop.addEventListener(evt, e => {
+      e.preventDefault();
+      drop.classList.add('file-zone__drop--over');
+    });
+  });
+  ['dragleave', 'dragend', 'drop'].forEach(evt => {
+    drop.addEventListener(evt, e => {
+      e.preventDefault();
+      drop.classList.remove('file-zone__drop--over');
+    });
+  });
+  drop.addEventListener('drop', e => {
+    const files = e.dataTransfer && e.dataTransfer.files;
+    if (!files || files.length === 0) return;
+    try {
+      const dt = new DataTransfer();
+      dt.items.add(files[0]);
+      input.files = dt.files;
+    } catch {
+      // Older browsers: fall back to file-input API directly.
+      input.files = files;
+    }
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+async function copyTranscript() {
+  const output = document.getElementById('output');
+  const btn = document.getElementById('copy-btn');
+  const text = output.textContent || '';
+  if (!text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    const orig = btn.textContent;
+    btn.textContent = 'COPIED';
+    btn.classList.add('copy-btn--confirmed');
+    setTimeout(() => {
+      btn.textContent = orig;
+      btn.classList.remove('copy-btn--confirmed');
+    }, 1200);
+  } catch {
+    btn.textContent = 'COPY FAILED';
+    setTimeout(() => { btn.textContent = 'COPY'; }, 1500);
+  }
+}
+
+function updateCopyButtonState() {
+  const btn = document.getElementById('copy-btn');
+  const output = document.getElementById('output');
+  const hasText = output.textContent && output.textContent.trim() !== '' && output.textContent !== 'Waiting for data stream...';
+  btn.disabled = !hasText;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const current = document.documentElement.getAttribute('data-theme');
   const themeBtn = document.getElementById('theme-btn');
@@ -292,6 +400,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('form').addEventListener('submit', startJob);
   themeBtn.addEventListener('click', toggleTheme);
-  document.getElementById('history-btn').addEventListener('click', toggleHistory);
-  document.getElementById('history-close').addEventListener('click', toggleHistory);
+  document.getElementById('history-btn').addEventListener('click', openHistory);
+  document.getElementById('history-close').addEventListener('click', closeHistory);
+  document.getElementById('copy-btn').addEventListener('click', copyTranscript);
+
+  wireFileZone();
+
+  const output = document.getElementById('output');
+  new MutationObserver(updateCopyButtonState).observe(output, { characterData: true, childList: true, subtree: true });
+  updateCopyButtonState();
 });

--- a/whisper_video_to_text/web/static/style.css
+++ b/whisper_video_to_text/web/static/style.css
@@ -177,6 +177,20 @@ em {
   }
 }
 
+@media (max-width: 900px) {
+  .status-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  .status-card__elapsed { text-align: left; }
+  .phase {
+    grid-template-columns: auto auto 1fr auto;
+    font-size: 0.7rem;
+  }
+  .phase-label { min-width: auto; }
+}
+
 @media (max-width: 640px) {
   .grid-container {
     margin: 1rem;
@@ -187,6 +201,8 @@ em {
     gap: 0.5rem;
   }
   .nav-bar__status { display: none; }
+  .row { flex-direction: column; }
+  .format-fieldset { gap: 0.75rem; }
 }
 
 .grid-item {
@@ -253,18 +269,89 @@ select:focus {
   border-color: var(--accent-yellow);
 }
 
-input[type="file"] {
-  width: 100%;
-  padding: 1rem;
-  background: var(--bg-surface);
-  border: 1px dashed var(--border-light);
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  cursor: pointer;
+/* File drop zone */
+.file-zone {
+  position: relative;
+  margin-top: 0.25rem;
 }
 
-input[type="file"]:hover { border-color: var(--text-secondary); }
+.file-zone__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.file-zone__drop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1.5rem 1rem;
+  background: var(--bg-surface);
+  border: 1px dashed var(--border-light);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-align: center;
+  margin: 0;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.file-zone__drop:hover { border-color: var(--text-secondary); }
+
+.file-zone__drop--over {
+  border-color: var(--accent-yellow);
+  border-style: solid;
+  background: color-mix(in srgb, var(--accent-yellow) 8%, var(--bg-surface));
+  color: var(--accent-yellow);
+}
+
+.file-zone__glyph {
+  font-family: var(--font-mono);
+  font-size: 1.4rem;
+  color: var(--text-meta);
+}
+
+.file-zone__drop--over .file-zone__glyph { color: var(--accent-yellow); }
+
+.file-zone__link {
+  color: var(--accent-yellow);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.file-zone__hint { margin-top: 0.25rem; }
+
+.file-zone__preview {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--accent-yellow);
+}
+
+.file-zone__preview-name {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.file-zone__preview-meta { margin-top: 0.25rem; }
+
+.file-zone__remove {
+  flex-shrink: 0;
+}
 
 .checkbox-row {
   margin-top: 1.5rem;
@@ -282,6 +369,42 @@ input[type="file"]:hover { border-color: var(--text-secondary); }
 .checkbox-label {
   margin: 0;
   cursor: pointer;
+}
+
+/* Format fieldset */
+.format-fieldset {
+  margin: 1.5rem 0 0;
+  padding: 0;
+  border: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.format-fieldset legend {
+  padding: 0;
+  margin-right: 0.5rem;
+}
+
+.checkbox-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-transform: none;
+}
+
+.checkbox-inline input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+  accent-color: var(--accent-yellow);
 }
 
 /* Buttons */
@@ -354,6 +477,24 @@ input[type="file"]:hover { border-color: var(--text-secondary); }
 }
 
 .error-text { color: var(--accent-alert); }
+
+/* Focus ring — single consistent visual cue across all focusable elements */
+:focus-visible {
+  outline: 2px solid var(--accent-yellow);
+  outline-offset: 2px;
+}
+
+input[type="text"]:focus-visible,
+input[type="number"]:focus-visible,
+select:focus-visible {
+  outline-offset: 0;
+}
+
+.file-zone__drop:focus-within {
+  border-color: var(--accent-yellow);
+  outline: 2px solid var(--accent-yellow);
+  outline-offset: 2px;
+}
 
 /* Row / divider */
 .row { display: flex; gap: 1rem; }
@@ -529,6 +670,33 @@ body.flash-success .phase--complete .phase-label { color: var(--accent-success);
   flex: 1;
 }
 
+.transcript-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.transcript-card__header label {
+  margin: 0;
+}
+
+.copy-btn {
+  position: relative;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.copy-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.copy-btn--confirmed {
+  color: var(--accent-success);
+  border-color: var(--accent-success);
+}
+
 .transcript {
   flex: 1;
   white-space: pre-wrap;
@@ -543,23 +711,31 @@ body.flash-success .phase--complete .phase-label { color: var(--accent-success);
   margin: 0;
 }
 
-/* Modal */
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.8);
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
+/* Modal (<dialog>) */
+dialog.modal {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  max-width: min(800px, calc(100% - 2rem));
+  width: 100%;
+  max-height: 80vh;
+  margin: auto;
+  overflow: visible;
 }
 
-.modal[hidden] { display: none; }
+dialog.modal::backdrop {
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+dialog.modal[open] {
+  display: block;
+}
 
 .modal__panel {
   width: 100%;
-  max-width: 800px;
   max-height: 80vh;
   overflow-y: auto;
   background: var(--bg-surface);

--- a/whisper_video_to_text/web/templates/index.html
+++ b/whisper_video_to_text/web/templates/index.html
@@ -47,8 +47,23 @@
       <form id="form">
         <div class="card">
           <label for="file">SOURCE MEDIA FILE</label>
-          <input id="file" name="file" type="file"
-            accept=".mp3,.wav,.aif,.aiff,.mp4,.mov,audio/mpeg,audio/wav,audio/aiff,video/mp4,video/quicktime" />
+          <div class="file-zone" id="file-zone">
+            <input id="file" name="file" type="file"
+              class="file-zone__input"
+              accept=".mp3,.wav,.aif,.aiff,.mp4,.mov,audio/mpeg,audio/wav,audio/aiff,video/mp4,video/quicktime" />
+            <label for="file" class="file-zone__drop" id="file-zone-drop">
+              <span class="file-zone__glyph" aria-hidden="true">↓</span>
+              <span class="file-zone__text">Drop a file here or <span class="file-zone__link">browse</span></span>
+              <span class="meta file-zone__hint">.MP3 · .WAV · .AIF · .AIFF · .MP4 · .MOV</span>
+            </label>
+            <div class="file-zone__preview" id="file-preview" hidden>
+              <div class="file-zone__preview-body">
+                <div class="file-zone__preview-name" id="file-preview-name"></div>
+                <div class="meta file-zone__preview-meta" id="file-preview-size"></div>
+              </div>
+              <button type="button" id="file-remove" class="btn btn-compact file-zone__remove">REMOVE</button>
+            </div>
+          </div>
 
           <div class="divider-text">OR</div>
 
@@ -78,6 +93,22 @@
             <input type="checkbox" name="timestamps" id="timestamps">
             <label for="timestamps" class="checkbox-label">INCLUDE TIMESTAMPS</label>
           </div>
+
+          <fieldset class="format-fieldset">
+            <legend class="meta">OUTPUT FORMATS</legend>
+            <label class="checkbox-inline">
+              <input type="checkbox" name="formats" value="txt" checked>
+              <span>TXT</span>
+            </label>
+            <label class="checkbox-inline">
+              <input type="checkbox" name="formats" value="srt">
+              <span>SRT</span>
+            </label>
+            <label class="checkbox-inline">
+              <input type="checkbox" name="formats" value="vtt">
+              <span>VTT</span>
+            </label>
+          </fieldset>
         </div>
 
         <div id="form-error" class="form-error" role="alert" hidden></div>
@@ -116,22 +147,25 @@
       </div>
 
       <div class="card transcript-card">
-        <label>TRANSCRIPT LOG</label>
+        <div class="transcript-card__header">
+          <label>TRANSCRIPT LOG</label>
+          <button type="button" id="copy-btn" class="btn btn-compact copy-btn" disabled>COPY</button>
+        </div>
         <pre id="output" class="transcript">Waiting for data stream...</pre>
       </div>
     </section>
 
   </main>
 
-  <div id="history-modal" class="modal" hidden>
+  <dialog id="history-modal" class="modal" aria-labelledby="history-title">
     <div class="modal__panel card">
       <div class="modal__header">
-        <h3>Transcript <em>History</em></h3>
+        <h3 id="history-title">Transcript <em>History</em></h3>
         <button id="history-close" class="btn btn-compact" type="button">CLOSE</button>
       </div>
       <div id="history-list" class="modal__list"></div>
     </div>
-  </div>
+  </dialog>
 
 </body>
 


### PR DESCRIPTION
Stacked on top of #6 — merge #6 first, then this.

## Summary

**P2 (UX & accessibility)**
- Real drag-and-drop file zone with name + human-readable size preview and a REMOVE button.
- History overlay converted from a hand-rolled div to a native \`<dialog>\` — focus trap, Escape-to-close, and ::backdrop blur come for free.
- Copy-transcript button next to the transcript log, enabled once text arrives; flashes COPIED/COPY FAILED briefly on click.
- Single \`:focus-visible\` rule gives every focusable element a visible yellow outline.
- New 900px breakpoint tightens the phase ladder + status header before the 1000px single-column collapse.

**P3 (polish)**
- Output format picker (TXT / SRT / VTT) as a \`<fieldset>\` of checkboxes. The existing backend \`form.getlist("formats")\` path handles multi-select with no changes.
- Dead \`.text-center\` / \`.muted\` utilities were already dropped in #6; grep confirms zero references remain.

No backend changes. \`/api/transcribe\`, \`/events/:id\`, \`/download/:id/:ext\`, and \`/api/history\` contracts unchanged.

## Test plan
- [x] \`uv run pytest\` — 47/47 passing
- [x] \`node --check\` on app.js — syntax OK
- [x] Smoke test: uvicorn boots, \`/\`, \`/static/app.js\`, \`/static/style.css\` all 200
- [ ] Manual: drag an .mp4 onto the zone — name + size appear, submit succeeds
- [ ] Manual: click REMOVE — zone resets
- [ ] Manual: open HISTORY — \`<dialog>\` focus-trapped, Escape closes
- [ ] Manual: run a job, check all three formats; three DOWNLOAD buttons appear
- [ ] Manual: click COPY on a completed transcript — clipboard contains text, button flashes COPIED
- [ ] Manual: Tab through the form — visible yellow focus ring on every control
- [ ] Manual: resize to 900px and 375px — phase ladder remains legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)