### PR TITLE
feat(web): adopt Nord design system as the site theme

### DIFF
--- a/whisper_video_to_text/web/static/nord-theme.css
+++ b/whisper_video_to_text/web/static/nord-theme.css
@@ -1,0 +1,333 @@
+/*
+ * Nord Design System — theme kernel
+ * Adapted from https://github.com/daryllundy/nord-design-system
+ * Provides design tokens (dark + light), base reset, and component primitives.
+ */
+
+:root,
+[data-theme="dark"] {
+  /* Polar Night / Snow Storm / Frost / Aurora */
+  --nord0: #2e3440;
+  --nord1: #3b4252;
+  --nord2: #434c5e;
+  --nord3: #4c566a;
+  --nord4: #d8dee9;
+  --nord5: #e5e9f0;
+  --nord6: #eceff4;
+  --nord7: #8fbcbb;
+  --nord8: #88c0d0;
+  --nord9: #81a1c1;
+  --nord10: #5e81ac;
+  --nord11: #bf616a;
+  --nord12: #d08770;
+  --nord13: #ebcb8b;
+  --nord14: #a3be8c;
+  --nord15: #b48ead;
+
+  /* Semantic surface + text (dark) */
+  --color-bg: var(--nord0);
+  --color-surface: var(--nord1);
+  --color-surface-alt: var(--nord2);
+  --color-border: var(--nord3);
+  --color-border-strong: color-mix(in srgb, var(--nord3) 60%, var(--nord4));
+  --color-text: var(--nord5);
+  --color-text-muted: color-mix(in srgb, var(--nord4) 75%, var(--nord3));
+  --color-heading: var(--nord6);
+
+  /* Accents */
+  --color-primary: var(--nord8);
+  --color-primary-strong: var(--nord10);
+  --color-accent: var(--nord7);
+  --color-focus: var(--nord9);
+  --color-success: var(--nord14);
+  --color-warning: var(--nord12);
+  --color-danger: var(--nord11);
+  --color-info: var(--nord9);
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Radii */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+
+  /* Shadows (tuned for Arctic backgrounds) */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.35);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  /* Motion */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --duration-fast: 120ms;
+  --duration-med: 220ms;
+}
+
+[data-theme="light"] {
+  --color-bg: var(--nord6);
+  --color-surface: #ffffff;
+  --color-surface-alt: var(--nord5);
+  --color-border: color-mix(in srgb, var(--nord4) 75%, var(--nord3));
+  --color-border-strong: var(--nord3);
+  --color-text: var(--nord0);
+  --color-text-muted: color-mix(in srgb, var(--nord3) 80%, var(--nord0));
+  --color-heading: var(--nord0);
+
+  --color-primary: var(--nord10);
+  --color-primary-strong: color-mix(in srgb, var(--nord10) 75%, #000);
+  --color-accent: color-mix(in srgb, var(--nord7) 80%, var(--nord10));
+  --color-focus: var(--nord10);
+  --color-success: color-mix(in srgb, var(--nord14) 80%, #000);
+  --color-warning: color-mix(in srgb, var(--nord12) 80%, #000);
+  --color-danger: color-mix(in srgb, var(--nord11) 80%, #000);
+  --color-info: var(--nord10);
+
+  --shadow-sm: 0 1px 2px rgba(46, 52, 64, 0.1);
+  --shadow-md: 0 4px 12px rgba(46, 52, 64, 0.12);
+  --shadow-lg: 0 12px 32px rgba(46, 52, 64, 0.18);
+}
+
+/* ─── Base reset ───────────────────────────────────────── */
+
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  color: var(--color-heading);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration-color: color-mix(in srgb, var(--color-primary) 50%, transparent);
+  text-underline-offset: 3px;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+a:hover { color: var(--color-primary-strong); }
+
+:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ─── Buttons ──────────────────────────────────────────── */
+
+.button,
+button.button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  background: var(--color-primary);
+  color: var(--nord0);
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.button:hover {
+  background: var(--color-primary-strong);
+  border-color: var(--color-primary-strong);
+  color: var(--nord6);
+  box-shadow: var(--shadow-sm);
+}
+
+.button:active { transform: translateY(1px); }
+
+.button:disabled,
+.button[aria-disabled="true"] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.button--ghost:hover {
+  background: var(--color-surface-alt);
+  border-color: var(--color-border-strong);
+  color: var(--color-heading);
+}
+
+.button--subtle {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border-color: transparent;
+}
+
+.button--subtle:hover {
+  background: color-mix(in srgb, var(--color-surface-alt) 70%, var(--color-primary));
+  color: var(--color-heading);
+}
+
+.button--danger {
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+  color: var(--nord6);
+}
+
+.button--danger:hover {
+  background: color-mix(in srgb, var(--color-danger) 80%, #000);
+  border-color: color-mix(in srgb, var(--color-danger) 80%, #000);
+}
+
+/* ─── Cards ────────────────────────────────────────────── */
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+/* ─── Fields ───────────────────────────────────────────── */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field__label,
+label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
+}
+
+.input,
+input[type="text"],
+input[type="number"],
+input[type="url"],
+input[type="search"],
+select,
+textarea {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  outline: none;
+  transition: border-color var(--duration-fast) var(--ease-out),
+              box-shadow var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+}
+
+.input:hover,
+input[type="text"]:hover,
+select:hover { border-color: var(--color-border-strong); }
+
+.input:focus,
+input[type="text"]:focus,
+input[type="number"]:focus,
+input[type="url"]:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 22%, transparent);
+}
+
+/* ─── Alerts ───────────────────────────────────────────── */
+
+.alert {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+
+.alert--danger {
+  border-color: color-mix(in srgb, var(--color-danger) 60%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-danger) 80%, var(--color-heading));
+}
+
+.alert--success {
+  border-color: color-mix(in srgb, var(--color-success) 60%, transparent);
+  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-success) 80%, var(--color-heading));
+}
+
+/* ─── Pills & badges ──────────────────────────────────── */
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.pill--primary {
+  background: color-mix(in srgb, var(--color-primary) 20%, transparent);
+  color: var(--color-primary);
+}
+
+.pill--success {
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+  color: var(--color-success);
+}
+
+.pill--danger {
+  background: color-mix(in srgb, var(--color-danger) 18%, transparent);
+  color: var(--color-danger);
+}
+
+/* ─── Utility tokens exposed for apps ─────────────────── */
+
+.text-muted { color: var(--color-text-muted); }
+.text-accent { color: var(--color-accent); }
+.surface { background: var(--color-surface); }

--- a/whisper_video_to_text/web/static/style.css
+++ b/whisper_video_to_text/web/static/style.css
@@ -1,84 +1,36 @@
-/* Signal Room — Luxurious Brutalism × Tech-Noir, refreshed */
-:root {
-  --bg-core: #050505;
-  --bg-surface: #0F0F0F;
-  --bg-surface-2: #1A1A1A;
+/*
+ * Whisper → Text — app styles, built on top of the Nord design system.
+ * All colors, radii, and typography flow through Nord tokens; this file
+ * composes app-specific components (phase ladder, file zone, transcript).
+ */
 
-  --text-primary: #FFFFFF;
-  --text-secondary: #888888;
-  --text-meta: #555555;
-
-  --accent-yellow: #F4D35E;
-  --accent-success: #7FB069;
-  --accent-alert: #FF3333;
-
-  --border-light: rgba(255, 255, 255, 0.08);
-  --border-active: rgba(255, 255, 255, 0.2);
-
-  --font-display: 'Instrument Serif', 'Iowan Old Style', 'Apple Garamond', Georgia, serif;
-  --font-body: 'Geist', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
-}
-
-[data-theme="light"] {
-  --bg-core: #F4F4F4;
-  --bg-surface: #FFFFFF;
-  --bg-surface-2: #EAEAEA;
-  --text-primary: #050505;
-  --text-secondary: #666666;
-  --text-meta: #777777;
-  --accent-success: #4F8F3F;
-  --border-light: rgba(0, 0, 0, 0.1);
-  --border-active: rgba(0, 0, 0, 0.2);
-}
-
-* { box-sizing: border-box; }
-
-html, body {
-  margin: 0;
-  padding: 0;
-  min-height: 100%;
-}
+html, body { min-height: 100%; }
 
 body {
-  font-family: var(--font-body);
-  background: var(--bg-core);
-  color: var(--text-primary);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  position: relative;
-  isolation: isolate;
+  background: var(--color-bg);
+  background-image:
+    radial-gradient(ellipse 800px 420px at 12% -10%, color-mix(in srgb, var(--color-primary) 18%, transparent), transparent 60%),
+    radial-gradient(ellipse 700px 360px at 110% 120%, color-mix(in srgb, var(--color-accent) 14%, transparent), transparent 60%);
+  background-attachment: fixed;
 }
 
-/* Grain overlay — fixed so it persists across scroll */
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: -1;
-  opacity: 0.05;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.6 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+[data-theme="light"] body {
+  background-image:
+    radial-gradient(ellipse 800px 420px at 12% -10%, color-mix(in srgb, var(--color-primary) 12%, transparent), transparent 60%),
+    radial-gradient(ellipse 700px 360px at 110% 120%, color-mix(in srgb, var(--color-accent) 10%, transparent), transparent 60%);
 }
 
-[data-theme="light"] body::before { opacity: 0.04; filter: invert(1); }
-
-h1, h2, h3 {
-  font-family: var(--font-display);
-  font-weight: 400;
-  letter-spacing: -0.01em;
-  margin: 0;
-}
-
-h1 { font-size: 2rem; }
-h2 { font-size: 1.5rem; }
-h3 { font-size: 1.35rem; }
+h1 { font-size: 1.85rem; }
+h2 { font-size: 1.45rem; }
+h3 { font-size: 1.2rem; }
 
 em {
-  font-family: var(--font-display);
   font-style: italic;
-  color: var(--accent-yellow);
+  color: var(--color-accent);
+  font-weight: 500;
 }
 
 .meta {
@@ -86,19 +38,20 @@ em {
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-meta);
+  color: var(--color-text-muted);
   font-variant-numeric: tabular-nums;
 }
 
 .section-heading { margin-bottom: 1rem; }
 
-/* Navigation */
+/* ─── Navigation ─────────────────────────────────────────── */
+
 .nav-bar {
-  background: color-mix(in srgb, var(--bg-core) 70%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 80%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border-light);
-  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.9rem 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -108,72 +61,76 @@ em {
 }
 
 .nav-bar__brand h3 {
-  font-size: 1.3rem;
+  font-size: 1.15rem;
   letter-spacing: -0.01em;
+  font-weight: 600;
 }
 
 .nav-bar__brand-arrow {
-  color: var(--text-meta);
+  color: var(--color-primary);
   font-family: var(--font-mono);
   font-size: 0.9rem;
-  font-style: normal;
 }
 
 .nav-bar__actions {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .nav-bar__status {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  color: var(--color-text-muted);
 }
 
 .nav-bar__status::before {
   content: "";
-  width: 6px;
-  height: 6px;
-  background: var(--accent-success);
+  width: 7px;
+  height: 7px;
+  background: var(--color-success);
   border-radius: 50%;
-  box-shadow: 0 0 8px currentColor;
-  color: var(--accent-success);
+  box-shadow: 0 0 10px var(--color-success);
 }
 
 .theme-toggle {
   background: transparent;
-  border: 1px solid var(--border-light);
-  color: var(--text-primary);
-  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: 0.45rem 0.9rem;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
   cursor: pointer;
   text-transform: uppercase;
-  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
-  border-radius: 0;
+  border-radius: var(--radius-md);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
 }
 
 .theme-toggle:hover {
-  background: var(--bg-surface-2);
-  border-color: var(--text-primary);
+  background: var(--color-surface-alt);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
-/* Layout */
+/* ─── Layout ─────────────────────────────────────────────── */
+
 .grid-container {
   display: grid;
   grid-template-columns: minmax(360px, 5fr) 7fr;
-  gap: 1px;
-  background-color: var(--border-light);
-  border: 1px solid var(--border-light);
+  gap: 1.25rem;
   flex: 1;
-  margin: 2rem;
+  padding: 2rem;
 }
 
 @media (max-width: 1000px) {
   .grid-container {
     grid-template-columns: 1fr;
-    margin: 1.5rem;
+    padding: 1.5rem;
   }
 }
 
@@ -192,9 +149,7 @@ em {
 }
 
 @media (max-width: 640px) {
-  .grid-container {
-    margin: 1rem;
-  }
+  .grid-container { padding: 1rem; gap: 1rem; }
   .nav-bar {
     padding: 0.75rem 1rem;
     flex-wrap: wrap;
@@ -206,70 +161,36 @@ em {
 }
 
 .grid-item {
-  background-color: var(--bg-core);
-  padding: 2rem;
   display: flex;
   flex-direction: column;
   min-width: 0;
+  gap: 1rem;
 }
 
-@media (max-width: 640px) {
-  .grid-item { padding: 1.25rem; }
-}
+.grid-item--output { gap: 1rem; }
 
-.grid-item--output { gap: 0; }
+/* ─── Cards — nord kernel provides base; tune spacing per-variant ─── */
 
-/* Cards */
-.card {
-  background: linear-gradient(180deg, var(--bg-surface) 0%, color-mix(in srgb, var(--bg-surface) 85%, #000) 100%);
-  border: 1px solid var(--border-light);
-  padding: 1.5rem;
-  margin-bottom: 1rem;
-  transition: border-color 120ms linear, transform 120ms ease-out;
-}
+.card { margin: 0; }
+.card + .card { margin-top: 0; }
 
-.card:hover {
-  transform: translateY(-1px);
-  border-color: var(--border-active);
-}
+/* Form field rhythm inside cards */
+.card > label:not(:first-child) { margin-top: 1rem; display: block; }
+.card > label:first-child { display: block; }
 
-[data-theme="light"] .card {
-  background: var(--bg-surface);
-}
-
-/* Form elements */
 label {
   display: block;
-  margin: 1rem 0 0.5rem;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  margin-bottom: 0.4rem;
+  font-size: 0.72rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-meta);
-}
-
-input[type="text"],
-input[type="number"],
-select {
-  width: 100%;
-  padding: 0.75rem;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-light);
-  color: var(--text-primary);
-  border-radius: 0;
+  color: var(--color-text-muted);
   font-family: var(--font-mono);
-  font-size: 0.9rem;
-  outline: none;
-  transition: border-color 120ms ease;
+  font-weight: 500;
 }
 
-input[type="text"]:focus,
-input[type="number"]:focus,
-select:focus {
-  border-color: var(--accent-yellow);
-}
+/* ─── File drop zone ─────────────────────────────────────── */
 
-/* File drop zone */
 .file-zone {
   position: relative;
   margin-top: 0.25rem;
@@ -292,48 +213,55 @@ select:focus {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
-  padding: 1.5rem 1rem;
-  background: var(--bg-surface);
-  border: 1px dashed var(--border-light);
-  color: var(--text-secondary);
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
+  gap: 0.5rem;
+  padding: 1.75rem 1rem;
+  background: color-mix(in srgb, var(--color-bg) 80%, var(--color-surface));
+  border: 1.5px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
   cursor: pointer;
   text-align: center;
   margin: 0;
-  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
 }
 
-.file-zone__drop:hover { border-color: var(--text-secondary); }
+.file-zone__drop:hover {
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
 
 .file-zone__drop--over {
-  border-color: var(--accent-yellow);
+  border-color: var(--color-primary);
   border-style: solid;
-  background: color-mix(in srgb, var(--accent-yellow) 8%, var(--bg-surface));
-  color: var(--accent-yellow);
+  background: color-mix(in srgb, var(--color-primary) 14%, var(--color-surface));
+  color: var(--color-primary);
 }
 
 .file-zone__drop--reject {
-  border-color: var(--accent-alert);
+  border-color: var(--color-danger);
   border-style: solid;
-  background: color-mix(in srgb, var(--accent-alert) 8%, var(--bg-surface));
-  color: var(--accent-alert);
+  background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface));
+  color: var(--color-danger);
   cursor: not-allowed;
 }
 
 .file-zone__glyph {
   font-family: var(--font-mono);
-  font-size: 1.4rem;
-  color: var(--text-meta);
-  transition: color 120ms ease;
+  font-size: 1.5rem;
+  color: var(--color-text-muted);
+  transition: color var(--duration-fast) var(--ease-out);
 }
 
-.file-zone__drop--over .file-zone__glyph { color: var(--accent-yellow); }
-.file-zone__drop--reject .file-zone__glyph { color: var(--accent-alert); }
+.file-zone__drop--over .file-zone__glyph { color: var(--color-primary); }
+.file-zone__drop--reject .file-zone__glyph { color: var(--color-danger); }
 
 .file-zone__link {
-  color: var(--accent-yellow);
+  color: var(--color-primary);
   text-decoration: underline;
   text-underline-offset: 3px;
 }
@@ -346,22 +274,25 @@ select:focus {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.85rem 1rem;
-  background: var(--bg-surface);
-  border: 1px solid var(--accent-yellow);
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
 }
+
+.file-zone__preview[hidden] { display: none; }
 
 .file-zone__preview-name {
   font-family: var(--font-mono);
   font-size: 0.85rem;
-  color: var(--text-primary);
+  color: var(--color-heading);
   word-break: break-all;
 }
 
-.file-zone__preview-meta { margin-top: 0.25rem; }
+.file-zone__preview-meta { margin-top: 0.2rem; }
 
-.file-zone__remove {
-  flex-shrink: 0;
-}
+.file-zone__remove { flex-shrink: 0; }
+
+/* ─── Checkboxes & inline controls ───────────────────────── */
 
 .checkbox-row {
   margin-top: 1.5rem;
@@ -373,15 +304,17 @@ select:focus {
 .checkbox-row input[type="checkbox"] {
   width: auto;
   margin: 0;
-  accent-color: var(--accent-yellow);
+  accent-color: var(--color-primary);
 }
 
 .checkbox-label {
   margin: 0;
   cursor: pointer;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
 }
 
-/* Format fieldset */
 .format-fieldset {
   margin: 1.5rem 0 0;
   padding: 0;
@@ -403,57 +336,70 @@ select:focus {
   gap: 0.4rem;
   margin: 0;
   padding: 0;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  color: var(--color-text);
   cursor: pointer;
   text-transform: none;
+  letter-spacing: 0;
 }
 
 .checkbox-inline input[type="checkbox"] {
   width: auto;
   margin: 0;
-  accent-color: var(--accent-yellow);
+  accent-color: var(--color-primary);
 }
 
-/* Buttons */
+/* ─── Buttons — preserves legacy .btn classes, reskinned via Nord ─── */
+
 .btn {
-  background-color: var(--bg-surface-2);
-  color: var(--text-primary);
-  border: 1px solid var(--border-light);
-  padding: 0.75rem 1.5rem;
-  font-family: var(--font-mono);
-  text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
+  appearance: none;
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  padding: 0.6rem 1.2rem;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  border-radius: 0;
-  transition: all 120ms ease;
-  margin-top: 1.5rem;
+  border-radius: var(--radius-md);
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+  margin-top: 1.25rem;
   width: 100%;
   text-align: center;
   text-decoration: none;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 .btn:hover {
-  background-color: var(--bg-surface);
-  border-color: var(--accent-yellow);
-  color: var(--accent-yellow);
+  background: color-mix(in srgb, var(--color-surface-alt) 70%, var(--color-primary));
+  border-color: var(--color-primary);
+  color: var(--color-heading);
+  box-shadow: var(--shadow-sm);
 }
 
+.btn:active { transform: translateY(1px); }
+
 .btn-primary {
-  background-color: var(--accent-yellow);
-  color: var(--bg-core);
-  border: 1px solid var(--accent-yellow);
+  background: var(--color-primary);
+  color: var(--nord0);
+  border-color: var(--color-primary);
   font-weight: 600;
 }
 
 .btn-primary:hover {
-  background-color: color-mix(in srgb, var(--accent-yellow) 88%, #000);
-  color: var(--bg-core);
-  border-color: var(--accent-yellow);
+  background: var(--color-primary-strong);
+  border-color: var(--color-primary-strong);
+  color: var(--nord6);
 }
 
 .btn-primary:disabled {
@@ -463,10 +409,11 @@ select:focus {
 
 .btn-compact,
 .btn-download--compact {
-  padding: 0.35rem 0.75rem;
-  font-size: 0.7rem;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.72rem;
   width: auto;
   margin-top: 0;
+  border-radius: var(--radius-sm);
 }
 
 .btn-download {
@@ -474,39 +421,23 @@ select:focus {
   width: auto;
 }
 
-/* Form error */
+/* ─── Form error ─────────────────────────────────────────── */
+
 .form-error {
   margin-top: 1rem;
   padding: 0.75rem 1rem;
-  border: 1px solid var(--accent-alert);
-  background: color-mix(in srgb, var(--accent-alert) 10%, transparent);
-  color: var(--accent-alert);
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  letter-spacing: 0.05em;
+  border: 1px solid color-mix(in srgb, var(--color-danger) 60%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-danger) 85%, var(--color-heading));
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  border-radius: var(--radius-md);
 }
 
-.error-text { color: var(--accent-alert); }
+.error-text { color: var(--color-danger); }
 
-/* Focus ring — single consistent visual cue across all focusable elements */
-:focus-visible {
-  outline: 2px solid var(--accent-yellow);
-  outline-offset: 2px;
-}
+/* ─── Row & divider ──────────────────────────────────────── */
 
-input[type="text"]:focus-visible,
-input[type="number"]:focus-visible,
-select:focus-visible {
-  outline-offset: 0;
-}
-
-.file-zone__drop:focus-within {
-  border-color: var(--accent-yellow);
-  outline: 2px solid var(--accent-yellow);
-  outline-offset: 2px;
-}
-
-/* Row / divider */
 .row { display: flex; gap: 1rem; }
 .row > * { flex: 1; }
 
@@ -515,7 +446,7 @@ select:focus-visible {
   margin: 1.5rem 0;
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--text-meta);
+  color: var(--color-text-muted);
   position: relative;
   letter-spacing: 0.2em;
 }
@@ -527,13 +458,14 @@ select:focus-visible {
   top: 50%;
   width: 40%;
   height: 1px;
-  background: var(--border-light);
+  background: var(--color-border);
 }
 
 .divider-text::before { left: 0; }
 .divider-text::after { right: 0; }
 
-/* Status card */
+/* ─── Status card ────────────────────────────────────────── */
+
 .status-card__header {
   display: flex;
   justify-content: space-between;
@@ -546,65 +478,74 @@ select:focus-visible {
 
 .status-card__state {
   font-family: var(--font-mono);
-  font-size: 1.3rem;
+  font-size: 1.25rem;
   font-weight: 500;
-  letter-spacing: 0.05em;
-  color: var(--text-primary);
+  letter-spacing: 0.04em;
+  color: var(--color-heading);
   margin-top: 0.25rem;
 }
 
-.status-card__state[data-state="queued"]     { color: var(--text-meta); }
+.status-card__state[data-state="queued"]     { color: var(--color-text-muted); }
 .status-card__state[data-state="uploading"],
 .status-card__state[data-state="downloading"],
 .status-card__state[data-state="converting"],
 .status-card__state[data-state="transcribing"],
-.status-card__state[data-state="saving"]     { color: var(--accent-yellow); }
-.status-card__state[data-state="complete"]   { color: var(--accent-success); }
-.status-card__state[data-state="error"]      { color: var(--accent-alert); }
+.status-card__state[data-state="saving"]     { color: var(--color-primary); }
+.status-card__state[data-state="complete"]   { color: var(--color-success); }
+.status-card__state[data-state="error"]      { color: var(--color-danger); }
 
 .status-card__timer {
   font-family: var(--font-mono);
-  font-size: 1.3rem;
+  font-size: 1.25rem;
   font-variant-numeric: tabular-nums;
-  color: var(--text-primary);
+  color: var(--color-heading);
   margin-top: 0.25rem;
 }
 
 .status-card__message {
   margin-bottom: 1.25rem;
   min-height: 1.2em;
+  color: var(--color-text-muted);
 }
 
-/* Phase ladder */
+/* ─── Phase ladder (signature moment) ────────────────────── */
+
 .phase-ladder {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.4rem;
   margin-top: 0.5rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .phase {
   display: grid;
-  grid-template-columns: auto minmax(80px, 120px) 1fr auto;
+  grid-template-columns: auto minmax(88px, 120px) 1fr auto;
   gap: 0.75rem;
   align-items: center;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.76rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.5rem 0;
-  border-top: 1px solid var(--border-light);
+  padding: 0.3rem 0;
 }
 
-.phase:last-child { border-bottom: 1px solid var(--border-light); }
-
-.phase-num { color: var(--text-meta); }
-.phase-name { color: var(--text-secondary); }
-.phase-label { color: var(--text-meta); font-size: 0.68rem; min-width: 70px; text-align: right; }
+.phase-num  { color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+.phase-name { color: var(--color-text-muted); }
+.phase-label {
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+  min-width: 70px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
 
 .phase-track {
   display: block;
-  height: 2px;
-  background: var(--border-light);
+  height: 3px;
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-pill);
   position: relative;
   overflow: hidden;
 }
@@ -613,18 +554,19 @@ select:focus-visible {
   display: block;
   height: 100%;
   width: 0%;
-  background: var(--text-meta);
-  transition: width 250ms ease-out;
+  background: var(--color-border-strong);
+  border-radius: inherit;
+  transition: width 280ms var(--ease-out), background var(--duration-med) var(--ease-out);
 }
 
 .phase--complete .phase-name,
-.phase--complete .phase-label { color: var(--text-primary); }
-.phase--complete .phase-track__fill { background: var(--text-primary); }
+.phase--complete .phase-label { color: var(--color-text); }
+.phase--complete .phase-track__fill { background: var(--color-accent); }
 
 .phase--active .phase-name,
-.phase--active .phase-label { color: var(--accent-yellow); }
-.phase--active .phase-num { color: var(--accent-yellow); }
-.phase--active .phase-track__fill { background: var(--accent-yellow); }
+.phase--active .phase-label,
+.phase--active .phase-num { color: var(--color-primary); }
+.phase--active .phase-track__fill { background: var(--color-primary); }
 
 .phase--active {
   animation: phase-breathe 1.6s ease-in-out infinite;
@@ -632,30 +574,31 @@ select:focus-visible {
 
 .phase--error .phase-name,
 .phase--error .phase-label,
-.phase--error .phase-num { color: var(--accent-alert); }
-.phase--error .phase-track__fill { background: var(--accent-alert); }
+.phase--error .phase-num { color: var(--color-danger); }
+.phase--error .phase-track__fill { background: var(--color-danger); }
 
 @keyframes phase-breathe {
   0%, 100% { opacity: 1; }
-  50%      { opacity: 0.6; }
+  50%      { opacity: 0.65; }
 }
 
-/* Complete state — green flash on body */
+/* Complete state — soft aurora glow on body */
 body.flash-success {
   animation: flash-success 900ms ease-out;
 }
 
 @keyframes flash-success {
-  0%   { box-shadow: inset 0 0 0 0 color-mix(in srgb, var(--accent-success) 40%, transparent); }
-  30%  { box-shadow: inset 0 0 120px 8px color-mix(in srgb, var(--accent-success) 28%, transparent); }
+  0%   { box-shadow: inset 0 0 0 0 color-mix(in srgb, var(--color-success) 0%, transparent); }
+  30%  { box-shadow: inset 0 0 160px 12px color-mix(in srgb, var(--color-success) 30%, transparent); }
   100% { box-shadow: inset 0 0 0 0 transparent; }
 }
 
-body.flash-success .phase--complete .phase-track__fill { background: var(--accent-success); }
+body.flash-success .phase--complete .phase-track__fill { background: var(--color-success); }
 body.flash-success .phase--complete .phase-name,
-body.flash-success .phase--complete .phase-label { color: var(--accent-success); }
+body.flash-success .phase--complete .phase-label { color: var(--color-success); }
 
-/* Downloads */
+/* ─── Downloads row ──────────────────────────────────────── */
+
 .downloads {
   display: flex;
   gap: 0.5rem;
@@ -665,15 +608,17 @@ body.flash-success .phase--complete .phase-label { color: var(--accent-success);
 
 .downloads[hidden] { display: none; }
 
-/* Worker card */
+/* ─── Worker card ────────────────────────────────────────── */
+
 .worker-card {
-  opacity: 0.5;
-  padding: 1rem 1.5rem;
+  opacity: 0.75;
+  padding: 0.9rem 1.5rem;
 }
 
 .worker-card__row { gap: 2rem; }
 
-/* Transcript */
+/* ─── Transcript ─────────────────────────────────────────── */
+
 .transcript-card {
   display: flex;
   flex-direction: column;
@@ -694,34 +639,40 @@ body.flash-success .phase--complete .phase-label { color: var(--accent-success);
 
 .copy-btn {
   position: relative;
-  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
 }
 
 .copy-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
 .copy-btn--confirmed {
-  color: var(--accent-success);
-  border-color: var(--accent-success);
+  color: var(--color-success);
+  border-color: var(--color-success);
 }
 
 .transcript {
   flex: 1;
   white-space: pre-wrap;
-  background: var(--bg-surface);
-  color: var(--text-secondary);
+  background: var(--color-bg);
+  color: var(--color-text);
   padding: 1rem;
-  border: 1px solid var(--border-light);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   font-family: var(--font-mono);
   font-size: 0.85rem;
+  line-height: 1.6;
   overflow: auto;
   max-height: 500px;
   margin: 0;
 }
 
-/* Modal (<dialog>) */
+/* ─── Modal (<dialog>) ───────────────────────────────────── */
+
 dialog.modal {
   padding: 0;
   border: none;
@@ -735,21 +686,21 @@ dialog.modal {
 }
 
 dialog.modal::backdrop {
-  background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  background: color-mix(in srgb, var(--nord0) 75%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
 }
 
-dialog.modal[open] {
-  display: block;
-}
+dialog.modal[open] { display: block; }
 
 .modal__panel {
   width: 100%;
   max-height: 80vh;
   overflow-y: auto;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-active);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
   margin: 0;
 }
 
@@ -757,30 +708,37 @@ dialog.modal[open] {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
   gap: 1rem;
 }
 
 .modal__list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-.history-item { margin-bottom: 0; }
+.history-item {
+  margin-bottom: 0;
+  padding: 0.9rem 1rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
 
 .history-item__row {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .history-item__id {
   font-family: var(--font-mono);
   font-size: 0.85rem;
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--color-heading);
 }
 
 .history-item__links {
@@ -789,24 +747,26 @@ dialog.modal[open] {
   flex-wrap: wrap;
 }
 
-/* Stagger reveal */
+/* ─── Stagger reveal ─────────────────────────────────────── */
+
 @keyframes reveal {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 
 .reveal {
-  animation: reveal 420ms ease-out both;
+  animation: reveal 420ms var(--ease-out) both;
 }
 
 .reveal-1 { animation-delay: 0ms; }
 .reveal-2 { animation-delay: 80ms; }
 .reveal-3 { animation-delay: 160ms; }
 
-/* Motion preferences */
+/* ─── Motion preferences ─────────────────────────────────── */
+
 @media (prefers-reduced-motion: reduce) {
   .reveal { animation: none; }
   .phase--active { animation: none; }
   body.flash-success { animation: none; }
-  .card, .phase-track__fill, .theme-toggle { transition: none; }
+  .card, .phase-track__fill, .theme-toggle, .btn, .button { transition: none; }
 }

--- a/whisper_video_to_text/web/templates/index.html
+++ b/whisper_video_to_text/web/templates/index.html
@@ -9,9 +9,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&family=Geist:wght@400;500;600&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
     rel="stylesheet">
 
+  <link rel="stylesheet" href="/static/nord-theme.css" />
   <link rel="stylesheet" href="/static/style.css" />
 
   <script>


### PR DESCRIPTION
## Summary

Replaces the Signal Room tech-noir palette with the Arctic-inspired **Nord design system** ([daryllundy/nord-design-system](https://github.com/daryllundy/nord-design-system)). The new theme kernel (`nord-theme.css`) provides tokens, base reset, and component primitives; app styles now compose on top of Nord tokens throughout.

- **Palette:** Polar Night surfaces (`#2e3440/#3b4252/#434c5e`) + Frost accents (`#88c0d0` primary, `#8fbcbb` aurora), Aurora alerts (`#bf616a/#a3be8c`)
- **Corners:** Rounded throughout (4/8/12px radii) — the sharp brutalist corners retire
- **Typography:** Inter + JetBrains Mono per Nord spec (Instrument Serif + Geist are gone)
- **Atmosphere:** Soft radial aurora gradients replace the SVG grain overlay
- **Phase ladder:** Frost primary for active + aurora green for complete — signature moment stays, in Arctic colors
- **Light mode:** Mapped to Snow Storm palette with stronger Frost primary (`#5e81ac`) for contrast

## Test plan

- [ ] Dark theme renders with Polar Night bg + Frost accents
- [ ] Light theme renders with Snow Storm bg + deeper Frost primary
- [ ] Theme toggle flips cleanly without FOUC
- [ ] File drop zone accept/reject verdicts use Frost primary / Aurora red
- [ ] Phase ladder lights phases in Frost; completion flashes Aurora green
- [ ] Focus rings visible on all form controls
- [ ] Reduced motion still disables stagger reveal + phase pulse

🤖 Generated with [Claude Code](https://claude.com/claude-code)