### PR TITLE
[codex] add Nord theme tokens

### DIFF
--- a/whisper_video_to_text/web/static/nord-theme.css
+++ b/whisper_video_to_text/web/static/nord-theme.css
@@ -1,0 +1,333 @@
+/*
+ * Nord Design System — theme kernel
+ * Adapted from https://github.com/daryllundy/nord-design-system
+ * Provides design tokens (dark + light), base reset, and component primitives.
+ */
+
+:root,
+[data-theme="dark"] {
+  /* Polar Night / Snow Storm / Frost / Aurora */
+  --nord0: #2e3440;
+  --nord1: #3b4252;
+  --nord2: #434c5e;
+  --nord3: #4c566a;
+  --nord4: #d8dee9;
+  --nord5: #e5e9f0;
+  --nord6: #eceff4;
+  --nord7: #8fbcbb;
+  --nord8: #88c0d0;
+  --nord9: #81a1c1;
+  --nord10: #5e81ac;
+  --nord11: #bf616a;
+  --nord12: #d08770;
+  --nord13: #ebcb8b;
+  --nord14: #a3be8c;
+  --nord15: #b48ead;
+
+  /* Semantic surface + text (dark) */
+  --color-bg: var(--nord0);
+  --color-surface: var(--nord1);
+  --color-surface-alt: var(--nord2);
+  --color-border: var(--nord3);
+  --color-border-strong: color-mix(in srgb, var(--nord3) 60%, var(--nord4));
+  --color-text: var(--nord5);
+  --color-text-muted: color-mix(in srgb, var(--nord4) 75%, var(--nord3));
+  --color-heading: var(--nord6);
+
+  /* Accents */
+  --color-primary: var(--nord8);
+  --color-primary-strong: var(--nord10);
+  --color-accent: var(--nord7);
+  --color-focus: var(--nord9);
+  --color-success: var(--nord14);
+  --color-warning: var(--nord12);
+  --color-danger: var(--nord11);
+  --color-info: var(--nord9);
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Radii */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+
+  /* Shadows (tuned for Arctic backgrounds) */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.35);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.45);
+
+  /* Motion */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --duration-fast: 120ms;
+  --duration-med: 220ms;
+}
+
+[data-theme="light"] {
+  --color-bg: var(--nord6);
+  --color-surface: #ffffff;
+  --color-surface-alt: var(--nord5);
+  --color-border: color-mix(in srgb, var(--nord4) 75%, var(--nord3));
+  --color-border-strong: var(--nord3);
+  --color-text: var(--nord0);
+  --color-text-muted: color-mix(in srgb, var(--nord3) 80%, var(--nord0));
+  --color-heading: var(--nord0);
+
+  --color-primary: var(--nord10);
+  --color-primary-strong: color-mix(in srgb, var(--nord10) 75%, #000);
+  --color-accent: color-mix(in srgb, var(--nord7) 80%, var(--nord10));
+  --color-focus: var(--nord10);
+  --color-success: color-mix(in srgb, var(--nord14) 80%, #000);
+  --color-warning: color-mix(in srgb, var(--nord12) 80%, #000);
+  --color-danger: color-mix(in srgb, var(--nord11) 80%, #000);
+  --color-info: var(--nord10);
+
+  --shadow-sm: 0 1px 2px rgba(46, 52, 64, 0.1);
+  --shadow-md: 0 4px 12px rgba(46, 52, 64, 0.12);
+  --shadow-lg: 0 12px 32px rgba(46, 52, 64, 0.18);
+}
+
+/* ─── Base reset ───────────────────────────────────────── */
+
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  color: var(--color-heading);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration-color: color-mix(in srgb, var(--color-primary) 50%, transparent);
+  text-underline-offset: 3px;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+a:hover { color: var(--color-primary-strong); }
+
+:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ─── Buttons ──────────────────────────────────────────── */
+
+.button,
+button.button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  background: var(--color-primary);
+  color: var(--nord0);
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.button:hover {
+  background: var(--color-primary-strong);
+  border-color: var(--color-primary-strong);
+  color: var(--nord6);
+  box-shadow: var(--shadow-sm);
+}
+
+.button:active { transform: translateY(1px); }
+
+.button:disabled,
+.button[aria-disabled="true"] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.button--ghost:hover {
+  background: var(--color-surface-alt);
+  border-color: var(--color-border-strong);
+  color: var(--color-heading);
+}
+
+.button--subtle {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border-color: transparent;
+}
+
+.button--subtle:hover {
+  background: color-mix(in srgb, var(--color-surface-alt) 70%, var(--color-primary));
+  color: var(--color-heading);
+}
+
+.button--danger {
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+  color: var(--nord6);
+}
+
+.button--danger:hover {
+  background: color-mix(in srgb, var(--color-danger) 80%, #000);
+  border-color: color-mix(in srgb, var(--color-danger) 80%, #000);
+}
+
+/* ─── Cards ────────────────────────────────────────────── */
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+/* ─── Fields ───────────────────────────────────────────── */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field__label,
+label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
+}
+
+.input,
+input[type="text"],
+input[type="number"],
+input[type="url"],
+input[type="search"],
+select,
+textarea {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  outline: none;
+  transition: border-color var(--duration-fast) var(--ease-out),
+              box-shadow var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+}
+
+.input:hover,
+input[type="text"]:hover,
+select:hover { border-color: var(--color-border-strong); }
+
+.input:focus,
+input[type="text"]:focus,
+input[type="number"]:focus,
+input[type="url"]:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 22%, transparent);
+}
+
+/* ─── Alerts ───────────────────────────────────────────── */
+
+.alert {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+
+.alert--danger {
+  border-color: color-mix(in srgb, var(--color-danger) 60%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-danger) 80%, var(--color-heading));
+}
+
+.alert--success {
+  border-color: color-mix(in srgb, var(--color-success) 60%, transparent);
+  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-success) 80%, var(--color-heading));
+}
+
+/* ─── Pills & badges ──────────────────────────────────── */
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.pill--primary {
+  background: color-mix(in srgb, var(--color-primary) 20%, transparent);
+  color: var(--color-primary);
+}
+
+.pill--success {
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+  color: var(--color-success);
+}
+
+.pill--danger {
+  background: color-mix(in srgb, var(--color-danger) 18%, transparent);
+  color: var(--color-danger);
+}
+
+/* ─── Utility tokens exposed for apps ─────────────────── */
+
+.text-muted { color: var(--color-text-muted); }
+.text-accent { color: var(--color-accent); }
+.surface { background: var(--color-surface); }

--- a/whisper_video_to_text/web/static/style.css
+++ b/whisper_video_to_text/web/static/style.css
@@ -1,35 +1,34 @@
-/* Signal Room — Luxurious Brutalism × Tech-Noir, refreshed */
+/* Signal Room layout, themed through the Nord token kernel. */
 :root {
-  --bg-core: #050505;
-  --bg-surface: #0F0F0F;
-  --bg-surface-2: #1A1A1A;
+  --bg-core: var(--color-bg);
+  --bg-surface: var(--color-surface);
+  --bg-surface-2: var(--color-surface-alt);
 
-  --text-primary: #FFFFFF;
-  --text-secondary: #888888;
-  --text-meta: #555555;
+  --text-primary: var(--color-heading);
+  --text-secondary: var(--color-text);
+  --text-meta: var(--color-text-muted);
 
-  --accent-yellow: #F4D35E;
-  --accent-success: #7FB069;
-  --accent-alert: #FF3333;
+  --accent-yellow: var(--color-primary);
+  --accent-success: var(--color-success);
+  --accent-alert: var(--color-danger);
 
-  --border-light: rgba(255, 255, 255, 0.08);
-  --border-active: rgba(255, 255, 255, 0.2);
+  --border-light: var(--color-border);
+  --border-active: var(--color-border-strong);
 
-  --font-display: 'Instrument Serif', 'Iowan Old Style', 'Apple Garamond', Georgia, serif;
-  --font-body: 'Geist', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+  --font-display: var(--font-sans);
+  --font-body: var(--font-sans);
 }
 
 [data-theme="light"] {
-  --bg-core: #F4F4F4;
-  --bg-surface: #FFFFFF;
-  --bg-surface-2: #EAEAEA;
-  --text-primary: #050505;
-  --text-secondary: #666666;
-  --text-meta: #777777;
-  --accent-success: #4F8F3F;
-  --border-light: rgba(0, 0, 0, 0.1);
-  --border-active: rgba(0, 0, 0, 0.2);
+  --bg-core: var(--color-bg);
+  --bg-surface: var(--color-surface);
+  --bg-surface-2: var(--color-surface-alt);
+  --text-primary: var(--color-heading);
+  --text-secondary: var(--color-text);
+  --text-meta: var(--color-text-muted);
+  --accent-success: var(--color-success);
+  --border-light: var(--color-border);
+  --border-active: var(--color-border-strong);
 }
 
 * { box-sizing: border-box; }
@@ -43,12 +42,22 @@ html, body {
 body {
   font-family: var(--font-body);
   background: var(--bg-core);
+  background-image:
+    radial-gradient(ellipse 800px 420px at 12% -10%, color-mix(in srgb, var(--color-primary) 18%, transparent), transparent 60%),
+    radial-gradient(ellipse 700px 360px at 110% 120%, color-mix(in srgb, var(--color-accent) 14%, transparent), transparent 60%);
+  background-attachment: fixed;
   color: var(--text-primary);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   position: relative;
   isolation: isolate;
+}
+
+[data-theme="light"] body {
+  background-image:
+    radial-gradient(ellipse 800px 420px at 12% -10%, color-mix(in srgb, var(--color-primary) 12%, transparent), transparent 60%),
+    radial-gradient(ellipse 700px 360px at 110% 120%, color-mix(in srgb, var(--color-accent) 10%, transparent), transparent 60%);
 }
 
 /* Grain overlay — fixed so it persists across scroll */
@@ -66,7 +75,7 @@ body::before {
 
 h1, h2, h3 {
   font-family: var(--font-display);
-  font-weight: 400;
+  font-weight: 600;
   letter-spacing: -0.01em;
   margin: 0;
 }
@@ -79,6 +88,7 @@ em {
   font-family: var(--font-display);
   font-style: italic;
   color: var(--accent-yellow);
+  font-weight: 500;
 }
 
 .meta {
@@ -151,7 +161,7 @@ em {
   cursor: pointer;
   text-transform: uppercase;
   transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
-  border-radius: 0;
+  border-radius: var(--radius-md);
 }
 
 .theme-toggle:hover {
@@ -207,9 +217,11 @@ em {
 .card {
   background: linear-gradient(180deg, var(--bg-surface) 0%, color-mix(in srgb, var(--bg-surface) 85%, #000) 100%);
   border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
   padding: 1.5rem;
   margin-bottom: 1rem;
   transition: border-color 120ms linear, transform 120ms ease-out;
+  box-shadow: var(--shadow-sm);
 }
 
 .card:hover {
@@ -240,7 +252,7 @@ select {
   background: var(--bg-surface);
   border: 1px solid var(--border-light);
   color: var(--text-primary);
-  border-radius: 0;
+  border-radius: var(--radius-md);
   font-family: var(--font-mono);
   font-size: 0.9rem;
   outline: none;
@@ -258,6 +270,7 @@ input[type="file"] {
   padding: 1rem;
   background: var(--bg-surface);
   border: 1px dashed var(--border-light);
+  border-radius: var(--radius-md);
   font-family: var(--font-mono);
   font-size: 0.8rem;
   color: var(--text-secondary);
@@ -295,7 +308,7 @@ input[type="file"]:hover { border-color: var(--text-secondary); }
   font-size: 0.8rem;
   letter-spacing: 0.08em;
   cursor: pointer;
-  border-radius: 0;
+  border-radius: var(--radius-md);
   transition: all 120ms ease;
   margin-top: 1.5rem;
   width: 100%;

--- a/whisper_video_to_text/web/templates/index.html
+++ b/whisper_video_to_text/web/templates/index.html
@@ -9,9 +9,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&family=Geist:wght@400;500;600&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
     rel="stylesheet">
 
+  <link rel="stylesheet" href="/static/nord-theme.css" />
   <link rel="stylesheet" href="/static/style.css" />
 
   <script>


### PR DESCRIPTION
## Summary

Adds the useful Nord theme pieces from the abandoned `ui-refactor-nord` branch without merging its stale UI structure.

The prior branch diverged from the current `main` web UI and conflicted in the JavaScript, template, and app stylesheet. This PR preserves the current `main` behavior while bringing over the reusable Nord design token layer and mapping the existing Signal Room layout onto those tokens.

## Changes

- Adds `nord-theme.css` as the Nord token kernel for dark and light themes, typography, radii, shadows, focus styles, and common primitives.
- Loads Inter and JetBrains Mono in the web template and includes `nord-theme.css` before the app stylesheet.
- Remaps the current app stylesheet variables to Nord semantic tokens for surfaces, text, borders, accents, shadows, and rounded controls.

## Validation

- `uv run pytest -q`
- Result: 47 passed
